### PR TITLE
Remove py3.7 from test matrix - main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         platform:
         - ubuntu-latest
         - macos-latest


### PR DESCRIPTION
Removed py3.7 from test matrix as it was failing due to f-string `f"{cmd=}"` format