### PR TITLE
Bump version: 0.12.0 → 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # PyGMC - Change Log
 
 ## Unreleased
+
+## 0.13.0 (2024-05-11)
 - Added WiFi commands
   - set_wifi_on, set_wifi_off, set_wifi_ssid, set_wifi_password
 - gmcmap.com commands

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "PyGMC"
 copyright = "2023, Thomaz"
 author = "Thomaz"
-release = "0.12.0"
+release = "0.13.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pygmc/__init__.py
+++ b/pygmc/__init__.py
@@ -7,7 +7,7 @@ readthedocs: https://pygmc.readthedocs.io/
 Thomaz - 2023
 """
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"
 __author__ = "Thomaz"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygmc"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
     {name = "Thomaz"},
 ]
@@ -143,7 +143,7 @@ line-ending = "auto"
 
 
 [tool.bumpversion]
-current_version = "0.12.0"
+current_version = "0.13.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"


### PR DESCRIPTION
- Added WiFi commands
  - set_wifi_on, set_wifi_off, set_wifi_ssid, set_wifi_password
- gmcmap.com commands
  - set_gmcmap_user_id, set_gmcmap_counter_id
- Added check for brltty udev rule that blocks USB on Ubuntu.
  - Gives user direction to fix Ubuntu issue connecting to GMC device.
- Reduced scope of get_connection_details()
  - Removed details not available in pyserial connection object.
- Bug fixes
  - Re-added all optional baudrates after learning the default can be modified.